### PR TITLE
Jean guillaume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+MVP1/code_candidat.txt
+MVP1/lecture_code_candidat.py
+


### PR DESCRIPTION
ajout d'un .gitignore

j'ai sur mon ordinateur des fichiers que je ne souhaite pas push parce qu'ils n'apportent rien (par exemple un fichier avec des fonctions tests. Pour le fichier code_candidat.txt c'est juste un duplicata que je supprimerai)
les fichiers dont j'écris le nom dans le .gitignore ne seront pas ajoutés au commit en faisant un git add .

Vous pouvez pull ce .gitignore et ajouter dedans le nom des fichiers de votre session que vous ne souhaiterez jamais mettre dans un push (sans enlever les miens)

pourquoi le .gitignore n'est-il pas lui même ignoré? On peut imaginer que chacun ait sur sa session un fichier identifiants à ne pas transmettre. On met ce nom de fichier dans le gitignore et il sera ignoré pour tous. De manière plus générale tout le monde peut avoir la même architecture sur son ordi sans avoir chacun à créer ses propres gitignore.
Bon en l'occurence ce ne sera pas forcément le cas, ajoutez juste vos noms de fichiers.
On verra si on peut faire ça plus clean